### PR TITLE
Fix bubble spawner leak (from Ultimate Regular Quake Patch)

### DIFF
--- a/player.qc
+++ b/player.qc
@@ -364,7 +364,10 @@ void() DeathBubblesSpawn =
 {
 	entity	bubble;
 	if (self.owner.waterlevel < 3)
+	{
+		remove(self);	// remove bubble spawner
 		return;
+	}
 	bubble = bubble_spawn(self.owner.origin + '0 0 24');
 
 	self.nextthink = time + 0.1;


### PR DESCRIPTION
When a player dies in water or slime, the entity which spawns the death bubbles does not clean up after itself properly. This will cause the server to run out of edicts eventually.

Originally fixed by Jonathan "Perged" Down for Ultimate Regular Quake Patch (see https://www.quake-info-pool.net/q1/qcfix.htm#bubbles).