### PR TITLE
Apply manual grenade bounce in cases where grenades would get stuck otherwise

### DIFF
--- a/m_ogre.qc
+++ b/m_ogre.qc
@@ -42,6 +42,8 @@ void() OgreGrenadeExplode =
 	T_ExplosiveTouch();
 }
 
+void() GrenadeHandlePhysics;
+
 void() OgreGrenadeTouch =
 {
 	if (other == self.owner) return;		// don't explode on owner
@@ -54,6 +56,9 @@ void() OgreGrenadeTouch =
 		OgreGrenadeExplode();
 		return;
 	}
+
+	GrenadeHandlePhysics();
+
 	sound (self, CHAN_VOICE, "weapons/bounce.wav", 1, ATTN_NORM);	// bounce sound
 	if (self.velocity == '0 0 0')
 		self.avelocity = '0 0 0';

--- a/maths.qc
+++ b/maths.qc
@@ -345,13 +345,13 @@ float(float num) sqrt =
 
 // reflect incident over normal, dampening it against the normal
 vector(vector incident, vector normal, float dampening) reflect = {
-    // project incident along normal
-    float d = incident * normal;
-    vector p = d * normal;
+	// project incident along normal
+	float d = incident * normal;
+	vector p = d * normal;
 
-    vector i2p = p - incident;
-    vector reflected = incident + 2 * i2p;
+	vector i2p = p - incident;
+	vector reflected = incident + 2 * i2p;
 
-    return reflected - d * dampening * normal;
+	return reflected - d * dampening * normal;
 };
 

--- a/maths.qc
+++ b/maths.qc
@@ -343,6 +343,15 @@ float(float num) sqrt =
 	return apr;
 }
 
+// reflect incident over normal, dampening it against the normal
+vector(vector incident, vector normal, float dampening) reflect = {
+    // project incident along normal
+    float d = incident * normal;
+    vector p = d * normal;
 
+    vector i2p = p - incident;
+    vector reflected = incident + 2 * i2p;
 
+    return reflected - d * dampening * normal;
+};
 

--- a/projectiles.qc
+++ b/projectiles.qc
@@ -508,4 +508,86 @@ entity(vector org, vector vel) launch_grenade =
 	return grenade;
 }
 
+// GRENADE PHYSICS PATCH //
 
+void(vector normal) GrenadeForceBounce;
+vector(vector incident, vector normal, float dampening) reflect;
+
+// From engine
+float GRENADE_BACKOFF = 1.5;
+
+void() GrenadeHandlePhysics = {
+	float dot;
+	vector horiz_vel, horiz_normal;
+
+	// if same frame that think was called
+	if (self.count == framecount) {
+		// end our shenanigans
+		self.velocity = '0 0 0';
+		return;
+	}
+
+	if (self.velocity_z > 0) {
+		return;
+	} 
+
+	if (self.velocity == '0 0 0') {
+		return;
+	}
+
+	traceline(
+			self.origin,
+			self.origin + self.velocity,
+			1,
+			self);
+
+	if (trace_ent != other || trace_plane_normal_z <= 0) {
+		return;
+	}
+
+	horiz_vel = self.velocity;
+	horiz_vel_z = 0;
+	horiz_normal = trace_plane_normal;
+	horiz_normal_z = 0;
+
+	dot = horiz_vel * horiz_normal;
+
+	// if moving down-slope, bounce
+	if (dot > 0) {
+		GrenadeForceBounce(trace_plane_normal);
+	// if surface slope is > 1/2
+	} else if (trace_plane_normal_z < 2*vlen(horiz_normal)) {
+		GrenadeForceBounce(trace_plane_normal);
+	}
+};
+
+void() GrenadeForceBounceThink = {
+
+	if (time >= self.pausetime) {
+		self.think1();
+	} else {
+		self.think = self.think1;
+		self.nextthink = self.pausetime;
+		self.velocity = self.pos1;
+		self.avelocity = '300 300 300';
+		self.flags = self.flags & (-1 - FL_ONGROUND);
+		self.count = framecount;
+	}
+};
+
+void(vector normal) GrenadeForceBounce = {
+	// bounce grenade off surface
+	self.velocity = reflect(-self.velocity, normal, 2-GRENADE_BACKOFF);
+
+	// cache velocity
+	self.pos1 = self.velocity;
+
+	// cache existing think
+	self.think1 = self.think;
+
+	self.pausetime = self.nextthink;
+
+	// FL_ONGROUND will get set, so clear it next frame
+	self.think = GrenadeForceBounceThink;
+	self.nextthink = time;
+};

--- a/w_rockets.qc
+++ b/w_rockets.qc
@@ -113,6 +113,8 @@ void() GrenadeExplode =
 	BecomeExplosion ();
 }
 
+void() GrenadeHandlePhysics;
+
 void() GrenadeTouch =
 {
 	if (other == self.owner ) return;		// don't explode on owner
@@ -124,6 +126,9 @@ void() GrenadeTouch =
 		T_ExplosiveTouch();
 		return;
 	}
+
+	GrenadeHandlePhysics();
+
 	sound (self, CHAN_WEAPON, "weapons/bounce.wav", 1, ATTN_NORM);	// bounce sound
 	if (self.velocity == '0 0 0')
 		self.avelocity = '0 0 0';


### PR DESCRIPTION
There's an engine bug where grenades fired into slopes at certain angles will get stuck.  From experimentation, I have found 2 different cases where this is the case:

* Grenade hits a surface while moving "down-slope*".  This occurs consistently
* Grenade hits a surface at a glancing angle moving "up-slope" when slope > 1/2.  This is a bit harder to reproduce, though can typically be seen when firing grenades from the top of the steps into the octagonal "pipe" in e2m7

This pull request attempts to fix the issue as conservatively as possible (i.e. rely on the engine to apply the bounce as possible) while missing as few cases as possible.  This is a best effort; there are cases where the engine will bounce the grenade while the bounce is performed QC-side (it's not clear what angles are "glancing", so bounces on all slopes >1/2 are a QC bounce) and cases where grenades still get stuck (theory: a grenade will come to a stop if it should bounce twice in a single frame AND the second bounce would fail on the engine due to 1 of the previous listed conditions.  Or: the QC code as-written cannot handle more than 1 bounce in a single frame, so remaining bounces would have to be handled by the engine).

The hope is that this patch will enable mappers to employ slopes more freely, and make encounters with elevated ogres more interesting.


*means horizontal component of the grenade is moving *down the slope*. Conversely, "up-slope" is when the horizontal component of the velocity is moving up the slope