### PR TITLE
 fix targeted misc_fireball not starting on

### DIFF
--- a/misc.qc
+++ b/misc.qc
@@ -742,8 +742,9 @@ void() misc_fireball =
 			self.use = lavaball_use;
 		else						// toggle on trigger
 		{
-			self.state = !(self.spawnflags & 1);
+			self.state = (self.spawnflags & 1);
 			self.use = lavaball_toggle;
+			lavaball_toggle();
 		}
 	}
 	


### PR DESCRIPTION
misc_fireball with a targetname and without the "start off" spawnflag is supposed to start on, and be toggled off when targeted. Before this fix, it would do nothing until it was targeted twice.